### PR TITLE
Added `openLib` as a workaround for different platforms

### DIFF
--- a/lib/sdl3/generated/lib_sdl.dart
+++ b/lib/sdl3/generated/lib_sdl.dart
@@ -4,7 +4,9 @@ import 'package:ffi/ffi.dart';
 import '../dylib.dart' as dylib;
 import 'struct_sdl.dart';
 
-final libSdl3 = dylib.dylibOpen('SDL3');
+DynamicLibrary libSdl3 = dylib.dylibOpen('SDL3');
+
+void openLib(String path) => libSdl3 = DynamicLibrary.open(path);
 
 // typedef SDL_AssertState (SDLCALL *SDL_AssertionHandler)( const SDL_AssertData *data, void *userdata)
 typedef SdlAssertionHandlerDart = int Function(


### PR DESCRIPTION
Hi, author of `sdl_gamepad` here.

The official implementation searches for a standard dylib called `SDL3`. On MacOS, this resolves to `libSDL3.dylib`. However, in a Flutter MacOS app, this should resolve to a special path, _inside_ the bundled application, with a different name (just `SDL3`, no `lib` or `.dylib`). So the search path needs to be overridden on Flutter apps. 

Calling this new function, `openLib`, before calling any other SDL function will successfully do so.